### PR TITLE
Update III-5,  erreur dans le code Ocaml

### DIFF
--- a/source/III/5-types-structures.html.md
+++ b/source/III/5-types-structures.html.md
@@ -29,11 +29,11 @@ Voici un exemple :
 
 ```ocaml
 let manon = {
-  nom : "Sélon" ;
-  prenom : "Manon" ;
-  age : 18 ;
-  telephone : (06, 06, 66, 66, 06) ; (* C’est un faux, n’essayez pas de l’appeler, merci. *)
-  email : "manon.selon@gmail.com" ;
+  nom = "Sélon" ;
+  prenom = "Manon" ;
+  age = 18 ;
+  telephone = (06, 06, 66, 66, 06) ; (* C’est un faux, n’essayez pas de l’appeler, merci. *)
+  email = "manon.selon@gmail.com" ;
 }
 ```
 


### PR DESCRIPTION
Salut 👋

Dans le cours indicé **III-5 «Bonus : les types structurés»**,  il y a une erreur dans le second bloc de code OCaml.

En effet, le premier bloc de code est la création eu type `contact` de la manière suivante :
```ocaml
type contact = {
  nom : string;
  prenom : string;
  age : int;
  telephone : int * int * int * int * int; (* 5 nombres séparés sont plus lisibles qu’un seul *)
  email : string;
}
```

Puis le second bloc donne un exemple de construction d'un contact : 
```ocaml
let manon = {
  nom : "Sélon" ;
  prenom : "Manon" ;
  age : 18 ;
  telephone : (06, 06, 66, 66, 06) ; (* C’est un faux, n’essayez pas de l’appeler, merci. *)
  email : "manon.selon@gmail.com" ;
}
```
Mais le problème c'est que pour la construction, il faut mettre des "=" au lieu des ":"

J'ai vérifié (avec OCaml v4.14.0)
![image](https://github.com/elegaanz/cours-ocaml/assets/98620482/5b254962-a004-44e8-b4fc-398d669615be)

Cette pull request propose donc simplement de remplacer les 5 ":" par des "=" dans le cours III-5

Bonne journée 😁
(c'est pratique de pouvoir écrire en français)